### PR TITLE
Update references for esphome-docs → esphome.io rename

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -52,7 +52,7 @@ All other stable releases:
   - Bump version on that branch to `{version}` using `script/bump-version.py` and commit.
   - Create a GitHub PR from `bump-{version}` to `release`.
 
-The same is repeated for `esphome-docs` with `s/dev/next/` and `s/release/current/`
+The same is repeated for `esphome.io` with `s/dev/next/` and `s/release/current/`
 
 ## PR Merging and Releasing
 

--- a/check_docs_prs.py
+++ b/check_docs_prs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Check all open PRs in esphome-docs for linked esphome PRs.
+Check all open PRs in esphome.io for linked esphome PRs.
 Flags docs PRs where the linked esphome PR has been merged.
 """
 
@@ -39,13 +39,13 @@ def run_gh_command(args: list[str]) -> str:
 
 
 def get_open_docs_prs() -> list[dict]:
-    """Get all open PRs from esphome-docs repo."""
+    """Get all open PRs from esphome.io repo."""
     output = run_gh_command(
         [
             "pr",
             "list",
             "--repo",
-            "esphome/esphome-docs",
+            "esphome/esphome.io",
             "--state",
             "open",
             "--limit",
@@ -106,7 +106,7 @@ def get_esphome_pr_state(pr_number: int) -> LinkedPR | None:
 
 
 def main():
-    print("Fetching open PRs from esphome-docs...")
+    print("Fetching open PRs from esphome.io...")
     docs_prs = get_open_docs_prs()
     print(f"Found {len(docs_prs)} open PRs\n")
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -2,7 +2,7 @@
   "editor": "code",
   "github_token": "<INSERT_YOUR_TOKEN>",
   "esphome_path": "../esphome",
-  "esphome_docs_path": "../esphome-docs",
+  "esphome_io_path": "../esphome.io",
   "esphome_hassio_path": "../home-assistant-addon",
   "esphome_issues_path": "../issues",
   "esphome_feature_requests_path": "../feature-requests"

--- a/esphomerelease/commands.py
+++ b/esphomerelease/commands.py
@@ -100,11 +100,11 @@ def reset():
     if click.confirm("Reset esphome/beta ?"):
         EsphomeProject.reset_hard_remote("beta")
 
-    if click.confirm("Reset esphome-docs/current ?"):
+    if click.confirm("Reset esphome.io/current ?"):
         EsphomeDocsProject.reset_hard_remote("current")
-    if click.confirm("Reset esphome-docs/next ?"):
+    if click.confirm("Reset esphome.io/next ?"):
         EsphomeDocsProject.reset_hard_remote("next")
-    if click.confirm("Reset esphome-docs/beta ?"):
+    if click.confirm("Reset esphome.io/beta ?"):
         EsphomeDocsProject.reset_hard_remote("beta")
 
     if click.confirm("Reset esphome-hassio/main ?"):
@@ -257,7 +257,7 @@ def labels():
         sess.repository("esphome", "issues"),
         sess.repository("esphome", "feature-requests"),
         sess.repository("esphome", "esphome"),
-        sess.repository("esphome", "esphome-docs"),
+        sess.repository("esphome", "esphome.io"),
     ]
     failed_to_update: dict[str, list[str]] = {}
     failed_to_create: dict[str, list[str]] = {}

--- a/esphomerelease/project.py
+++ b/esphomerelease/project.py
@@ -477,8 +477,8 @@ EsphomeProject = Project(
     dev_branch="dev",
 )
 EsphomeDocsProject = Project(
-    repo_name="esphome-docs",
-    path=CONFIG["esphome_docs_path"],
+    repo_name="esphome.io",
+    path=CONFIG.get("esphome_io_path", CONFIG.get("esphome_docs_path")),
     shortname="docs",
     stable_branch="current",
     beta_branch="beta",


### PR DESCRIPTION
## Summary

The docs repo was renamed on GitHub from `esphome-docs` to `esphome.io`. This updates:

- `repo_name` on `EsphomeDocsProject` and the `sess.repository(...)` call used to fetch the GitHub repo
- The `--repo` arg passed to `gh pr list` in `check_docs_prs.py`
- User-facing strings (reset confirmation prompts, docstrings, prints, NOTES.md)
- `config.sample.json` switched to `esphome_io_path` with `../esphome.io` as the default local path

For backward compatibility, `project.py` reads `esphome_io_path` and falls back to the legacy `esphome_docs_path` so existing local configs continue to work without edits.